### PR TITLE
python 3 port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.5"
 install:
   - pip install -Ue ".[test]"
 script:

--- a/docs/mailinglogger.txt
+++ b/docs/mailinglogger.txt
@@ -140,7 +140,7 @@ sending to ('to@example.com',) from 'from@example.com' using ('localhost', 25)
 Content-Type: text/plain; charset="us-ascii"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
-Subject:  
+Subject: 
 From: from@example.com
 To: to@example.com
 X-Mailer: MailingLogger...

--- a/docs/mailinglogger.txt
+++ b/docs/mailinglogger.txt
@@ -140,7 +140,7 @@ sending to ('to@example.com',) from 'from@example.com' using ('localhost', 25)
 Content-Type: text/plain; charset="us-ascii"
 MIME-Version: 1.0
 Content-Transfer-Encoding: 7bit
-Subject: 
+Subject:  
 From: from@example.com
 To: to@example.com
 X-Mailer: MailingLogger...

--- a/docs/subjectformatter.txt
+++ b/docs/subjectformatter.txt
@@ -45,7 +45,7 @@ format it with our formatter:
 ...               msg='msgline%i\nmsgline%i',
 ...               args=(1,2), 
 ...               exc_info=None)
->>> print formatter.format(record)
+>>> print(formatter.format(record))
 <BLANKLINE>
 'aname'
 10
@@ -73,7 +73,7 @@ first line of any message	 logged:
 We can now see how this formatter represents the log record
 generated previously:
 
->>> print f.format(record)
+>>> print(f.format(record))
 'msgline1'
 
 As you can see, this only includes the first line of the message
@@ -102,7 +102,7 @@ Normally, a logging formatter would include a traceback when
 representing this entry:
 
 >>> from logging import Formatter
->>> print Formatter().format(record)
+>>> print(Formatter().format(record))
 bad things caught
 Traceback (most recent call last):
   File "<doctest subjectformatter.txt[0]>", line 2, in <module>
@@ -111,7 +111,7 @@ NameError: name 'RuntimeException' is not defined
 However, if we use the subject formatter we previously created,
 the log entry is formatted as follows:
 
->>> print f.format(record)
+>>> print(f.format(record))
 'bad things caught'
 
 To aid administration where the same python software runs
@@ -119,7 +119,7 @@ on a cluster of machines, the hostname of the machine from which
 the message is logged can also be easilly included:
 
 >>> f = SubjectFormatter('[%(hostname)s] %(line)r')
->>> print f.format(record)
+>>> print(f.format(record))
 [host.example.com] 'bad things caught'
 
 Available LogRecord attributes

--- a/docs/summarisinglogger.txt
+++ b/docs/summarisinglogger.txt
@@ -84,16 +84,27 @@ The logging on script exit is done using python's :mod:`atexit`
 module. We can see that the handler we created above is now
 registered with this module by having a poke at its internals:
 
+>>> from mailinglogger.compat import PY2
 >>> import atexit
->>> print atexit._exithandlers
+>>> if PY2:
+...     atexit._exithandlers
 [(<bound method SummarisingLogger.close of <...>, (), {})]
+>>> if not PY2:
+...     atexit._ncallbacks()
+1
 
 This list can be manually cleared at any time to remove any
 registered :mod:`atexit` functions:
 
->>> atexit._exithandlers[:] = []
->>> print atexit._exithandlers
-[]
+>>> if PY2:
+...     atexit._exithandlers[:] = []
+... else:
+...     atexit._clear()
+>>> if PY2:
+...     len(atexit._exithandlers)
+... else:
+...     atexit._ncallbacks()
+0
 
 Now, to continue with the examples, just like any other handler, we
 can also set the logging level, which will filter out messages logged
@@ -137,7 +148,10 @@ Avoiding the :mod:`atexit` handler
 ----------------------------------
 
 .. 
-  >>> atexit._exithandlers[:] = []
+  >>> if PY2:
+  ...     atexit._exithandlers[:] = []
+  ... else:
+  ...     atexit._clear()
 
 In the event you wish to manually call the
 :meth:`~SummarisingLogger.close` method of the handler or use the
@@ -152,8 +166,11 @@ should be registered:
 
 Now, we can see that no :mod:`atexit` function has been registered:
 
->>> print atexit._exithandlers
-[]
+>>> if PY2:
+...     len(atexit._exithandlers)
+... else:
+...     atexit._ncallbacks()
+0
 
 With this configuration, if an entry is logged, the logging
 framework must be manually shut down for the mail to be sent:

--- a/mailinglogger/MailingLogger.py
+++ b/mailinglogger/MailingLogger.py
@@ -98,6 +98,8 @@ class MailingLogger(SMTPHandler):
 
             if isinstance(msg, Unicode):
                 email = MIMEText(msg, subtype, self.charset)
+            elif isinstance(msg, bytes):
+                email = MIMEText(msg.decode(self.charset), subtype)
             else:
                 email = MIMEText(msg, subtype)
 

--- a/mailinglogger/MailingLogger.py
+++ b/mailinglogger/MailingLogger.py
@@ -9,8 +9,8 @@ import datetime
 import os
 import smtplib
 
-from email.Utils import formatdate, make_msgid
-from email.MIMEText import MIMEText
+from .compat import formatdate, make_msgid, MIMEText, Unicode
+
 from logging.handlers import SMTPHandler
 from logging import LogRecord, CRITICAL
 from mailinglogger.common import SubjectFormatter
@@ -89,7 +89,14 @@ class MailingLogger(SMTPHandler):
             if self.template is not None:
                 msg = self.template % msg
             subtype = self.content_type.split('/')[-1]
-            if isinstance(msg, unicode):
+            # if possible, ascii encode it.
+            if isinstance(msg, Unicode):
+                try:
+                    msg = msg.encode('ascii')
+                except UnicodeEncodeError:
+                    pass
+
+            if isinstance(msg, Unicode):
                 email = MIMEText(msg, subtype, self.charset)
             else:
                 email = MIMEText(msg, subtype)

--- a/mailinglogger/SummarisingLogger.py
+++ b/mailinglogger/SummarisingLogger.py
@@ -111,17 +111,20 @@ class SummarisingLogger(FileHandler):
                 FileHandler.emit(self, record)
 
         FileHandler.close(self)
-        f = os.fdopen(self.fd)
+        if PY3:
+            f = os.fdopen(self.fd, encoding=self.charset)
+        else:
+            f = os.fdopen(self.fd)
         summary = f.read()
         if not PY3:
             summary = summary.decode(self.charset)
+            # try and encode in ascii, to keep emails simpler:
+            try:
+                summary = summary.encode('ascii')
+            except UnicodeEncodeError:
+                # unicode it is then
+                pass
         f.close()
-        # try and encode in ascii, to keep emails simpler:
-        try:
-            summary = summary.encode('ascii')
-        except UnicodeEncodeError:
-            # unicode it is then
-            pass
         if os.path.exists(self.filename):
             os.remove(self.filename)
         if self.send_level is None or self.maxlevelno >= self.send_level:

--- a/mailinglogger/SummarisingLogger.py
+++ b/mailinglogger/SummarisingLogger.py
@@ -5,6 +5,7 @@
 # See license.txt for more details.
 
 import os
+import sys
 
 from atexit import register
 from collections import deque
@@ -13,6 +14,8 @@ from mailinglogger.MailingLogger import MailingLogger
 from tempfile import mkstemp
 
 flood_template = '%i messages not included as flood limit of %i exceeded'
+
+PY3 = sys.version_info[:2] > (3, 0)
 
 
 class SummarisingLogger(FileHandler):
@@ -109,7 +112,9 @@ class SummarisingLogger(FileHandler):
 
         FileHandler.close(self)
         f = os.fdopen(self.fd)
-        summary = f.read().decode(self.charset)
+        summary = f.read()
+        if not PY3:
+            summary = summary.decode(self.charset)
         f.close()
         # try and encode in ascii, to keep emails simpler:
         try:

--- a/mailinglogger/common.py
+++ b/mailinglogger/common.py
@@ -4,7 +4,7 @@
 # http://www.opensource.org/licenses/mit-license.html
 # See license.txt for more details.
 
-from cgi import escape
+from .compat import escape
 from logging import Formatter
 from socket import gethostname
 
@@ -25,6 +25,6 @@ class SubjectFormatter(Formatter):
 class HTMLFilter(object):
 
     def filter(self, record):
-        record.msg = escape(record.getMessage())
+        record.msg = escape(record.getMessage(), quote=False)
         record.args = ()
         return True

--- a/mailinglogger/compat.py
+++ b/mailinglogger/compat.py
@@ -1,0 +1,22 @@
+# compatibility module for different python versions
+import sys
+
+if sys.version_info[:2] > (3, 0):
+
+    PY2 = False
+    PY3 = True
+
+    Unicode = str
+
+    from email.utils import formatdate, make_msgid
+    from email.mime.text import MIMEText
+
+else:
+
+    PY2 = True
+    PY3 = False
+
+    Unicode = unicode
+
+    from email.Utils import formatdate, make_msgid
+    from email.MIMEText import MIMEText

--- a/mailinglogger/compat.py
+++ b/mailinglogger/compat.py
@@ -11,6 +11,8 @@ if sys.version_info[:2] > (3, 0):
     from email.utils import formatdate, make_msgid
     from email.mime.text import MIMEText
 
+    from html import escape
+
 else:
 
     PY2 = True
@@ -20,3 +22,5 @@ else:
 
     from email.Utils import formatdate, make_msgid
     from email.MIMEText import MIMEText
+
+    from cgi import escape

--- a/mailinglogger/tests/shared.py
+++ b/mailinglogger/tests/shared.py
@@ -1,6 +1,8 @@
 from testfixtures import Replacer, test_datetime, test_time
 from time import tzset
 
+from mailinglogger.compat import PY2
+
 import atexit
 import logging
 import smtplib
@@ -133,4 +135,7 @@ def _tearDown(test, self=None):
     # make sure we have no dummy smtp
     DummySMTP.remove()
     # make sure we haven't registered any atexit funcs
-    atexit._exithandlers[:] = []
+    if PY2:
+        atexit._exithandlers[:] = []
+    else:
+        atexit._clear()

--- a/mailinglogger/tests/shared.py
+++ b/mailinglogger/tests/shared.py
@@ -8,7 +8,7 @@ import logging
 import smtplib
 
 
-class DummySMTP:
+class DummySMTP(object):
 
     broken = False
 
@@ -72,7 +72,7 @@ class DummySMTP:
         pass
 
 
-class Dummy:
+class Dummy(object):
 
     def __init__(self, value):
         self.value = value

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ this_dir = os.path.dirname(__file__)
 
 setup(
     name='mailinglogger',
-    version=file(os.path.join(this_dir,'mailinglogger','version.txt')).read().strip(),
+    version=open(os.path.join(this_dir,'mailinglogger','version.txt')).read().strip(),
     author='Chris Withers',
     author_email='chris@simplistix.co.uk',
     license='MIT',
@@ -28,7 +28,7 @@ setup(
     'Topic :: Communications :: Email',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Topic :: System :: Logging',
-    ],    
+    ],
     packages=find_packages(),
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Most probably it needs some tweaks as python 2 tests run super fast while, for some obscure network interaction on python 3 they take a lot of time.

`mailinglogger.txt` and `summarisinglogger.txt` tests seem to flicker as they may pass or not without a single line of code changed in between...

This pull request is mostly to try it on travis and see what it says.
