### PR TITLE
Make compatible with Python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 /.installed.cfg
+/.eggs/
 /bin/
+/build/
 /develop-eggs
 /dist
 /docs/_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
 script: coverage run --source mailinglogger -m pytest
 
 after_success:
-  - "COVERALLS_PARALLEL=true coveralls"
+  - "coveralls"
 
 jobs:
   include:
@@ -27,10 +27,8 @@ jobs:
       python: 3.8
       after_success: skip
 
-      install: "pip install -U coveralls coveralls-check"
-      script:
-        - "coveralls --finish"
-        - "coveralls-check $TRAVIS_COMMIT"
+      install: "pip install -U coveralls-check"
+      script: "coveralls-check $TRAVIS_COMMIT"
 
     - stage: release
       if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: python
 sudo: false
 
 python:
+  - "3.8"
   - "3.6"
   - "2.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,10 @@ jobs:
       python: 3.8
       after_success: skip
 
-      install: "pip install -U coveralls-check"
-      script: "coveralls-check $TRAVIS_COMMIT"
+      install: "pip install -U coveralls coveralls-check"
+      script:
+        - "coveralls --finish"
+        - "coveralls-check $TRAVIS_COMMIT"
 
     - stage: release
       if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
 
     - stage: coverage
       if: type != cron
-      python: 3.6
+      python: 3.8
       after_success: skip
 
       install: "pip install -U coveralls-check"
@@ -32,7 +32,7 @@ jobs:
 
     - stage: release
       if: tag IS present
-      python: 3.6
+      python: 3.8
       script: skip
       # work around https://github.com/travis-ci/travis-ci/issues/8337:
       after_success: true

--- a/docs/html.txt
+++ b/docs/html.txt
@@ -133,7 +133,7 @@ X-Mailer: MailingLogger ...
     }
     </style></head>
     <body><pre><tt class="INFO">2007-01-01 10:00:00 INFO     An info message</tt>
-<tt class="WARNING">2007-01-01 10:00:00 WARNING  Malformed html: &lt;a href="&gt;foo &amp;&amp;</tt>
+<tt class="WARNING">2007-01-01 10:00:00 WARNING  Malformed html: &lt;a href=&quot;&gt;foo &amp;&amp;</tt>
 <tt class="ERROR">2007-01-01 10:00:00 ERROR    An error</tt>
 <tt class="CRITICAL">2007-01-01 10:00:00 CRITICAL Something critical</tt>
 </pre></body></html>

--- a/mailinglogger/common.py
+++ b/mailinglogger/common.py
@@ -1,5 +1,5 @@
 from sys import version_info
-if version_info >= (3, 8):
+if version_info >= (3, 2):
     from html import escape
 else:
     from cgi import escape

--- a/mailinglogger/common.py
+++ b/mailinglogger/common.py
@@ -9,6 +9,11 @@ from socket import gethostname
 
 
 class SubjectFormatter(Formatter):
+    def __init__(self, fmt=None, datefmt=None):
+        if version_info >= (3, 8):
+            super().__init__(fmt, datefmt, validate=False)
+        else:
+            Formatter.__init__(fmt, datefmt)
 
     def format(self, record):
         record.message = record.getMessage()

--- a/mailinglogger/common.py
+++ b/mailinglogger/common.py
@@ -29,6 +29,6 @@ class SubjectFormatter(Formatter):
 class HTMLFilter(object):
 
     def filter(self, record):
-        record.msg = escape(record.getMessage())
+        record.msg = escape(record.getMessage(), quote=True)
         record.args = ()
         return True

--- a/mailinglogger/common.py
+++ b/mailinglogger/common.py
@@ -1,4 +1,9 @@
-from cgi import escape
+from sys import version_info
+if version_info >= (3, 8):
+    from html import escape
+else:
+    from cgi import escape
+
 from logging import Formatter
 from socket import gethostname
 

--- a/mailinglogger/common.py
+++ b/mailinglogger/common.py
@@ -13,7 +13,7 @@ class SubjectFormatter(Formatter):
         if version_info >= (3, 8):
             super().__init__(fmt, datefmt, validate=False)
         else:
-            Formatter.__init__(fmt, datefmt)
+            Formatter.__init__(self, fmt, datefmt)
 
     def format(self, record):
         record.message = record.getMessage()


### PR DESCRIPTION
Python 3.8 removed the `escape` function from `cgi` package stating security issues and recommending the same function from `html` package which has a different default parameter.