### PR TITLE
Fix CircleCI badge and link to project to push to

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,8 +3,8 @@ MailingLogger
 
 |CircleCI|_ |Docs|_
 
-.. |CircleCI| image:: https://circleci.com/gh/cjw296/sybil/tree/master.svg?style=shield
-.. _CircleCI: https://circleci.com/gh/cjw296/sybil/tree/master
+.. |CircleCI| image:: https://circleci.com/gh/Simplistix/mailinglogger.svg?style=shield
+.. _CircleCI: https://circleci.com/gh/Simplistix/mailinglogger/tree/master
 
 .. |Docs| image:: https://readthedocs.org/projects/mailinglogger/badge/?version=latest
 .. _Docs: http://mailinglogger.readthedocs.org/en/latest/

--- a/docs/development.txt
+++ b/docs/development.txt
@@ -57,5 +57,5 @@ Making a release
 ----------------
 
 To make a release, just update the version in ``setup.py``,
-and push to https://github.com/cjw296/sybil
+and push to https://github.com/Simplistix/mailinglogger
 and Carthorse should take care of the rest.


### PR DESCRIPTION
The CircleCI badge points to a different project and I think the development instruction should also read to push to the _mailinglogger_ project.