### PR TITLE
Build on python 3.9 and 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,8 @@ common: &common
               - circleci/python:2.7
               - circleci/python:3.6
               - circleci/python:3.8
+              - circleci/python:3.9
+              - circleci/python:3.10
 
     - python/coverage:
         name: coverage


### PR DESCRIPTION
mailinglogger works on Python 3.9 and 3.10 and the CI should build this automatically.