### PR TITLE
Support TLS connections to the SMTP server

### DIFF
--- a/docs/api.txt
+++ b/docs/api.txt
@@ -117,6 +117,19 @@ API Reference
     on any email sent. Only content types of ``text/`` are supported.
    
     default: ``text/plain``
+  
+  :param secure:
+
+    If TLS is required, this must be an empty tuple ``()`` or a tuple
+    containing either one ``(keyfile)`` or two ``(keyfile, certfile)``
+    parameters. See `smtplib SMTP.starttls()`__ for details.
+
+    __ https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.starttls
+
+    ..  note:: If TLS is required, both username and password must also be
+               provided.
+
+    default: ``None``
 
 .. autoclass:: SummarisingLogger
   :show-inheritance:
@@ -246,6 +259,19 @@ API Reference
     on any email sent. Only content types of ``text/`` are supported.
    
     default: ``text/plain``
+  
+  :param secure:
+
+    If TLS is required, this must be an empty tuple ``()`` or a tuple
+    containing either one ``(keyfile)`` or two ``(keyfile, certfile)``
+    parameters. See `smtplib SMTP.starttls()`__ for details.
+
+    __ https://docs.python.org/3/library/smtplib.html#smtplib.SMTP.starttls
+
+    ..  note:: If TLS is required, both username and password must also be
+               provided.
+
+    default: ``None``
 
   :param flood_level:
 

--- a/docs/mailinglogger.txt
+++ b/docs/mailinglogger.txt
@@ -332,6 +332,37 @@ An Error
   For performance reasons, it's recommended that you don't use SMTP
   authentication unless you absolutely need to.
 
+If the smtp server you wish to use requires TLS (Transport Level Security),
+pass the required username and password and the secure parameter to the
+:class:`MailingLogger` constructor. ``secure`` must be an empty tuple or
+contain one or two members. See the `smtplib`__ documentation for details:
+
+__ https://docs.python.org/3/library/smtplib.html
+
+.. invisible-code-block: python
+
+  logging.getLogger('').removeHandler(handler)
+
+>>> handler = MailingLogger('from@example.com',('to@example.com',),
+...                         username='auser',password='theirpassword',
+...                         secure=())
+>>> logger.addHandler(handler)
+>>> logging.error('An Error')
+sending to ('to@example.com',) from 'from@example.com' using ('localhost', 25)
+(authenticated using username:'auser' and password:'theirpassword')
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain; charset="us-ascii"
+Date: ...
+From: from@example.com
+MIME-Version: 1.0
+Message-ID: <...MailingLogger@...>
+Subject: An Error
+To: to@example.com
+X-Log-Level: ERROR
+X-Mailer: MailingLogger...
+<BLANKLINE>
+An Error
+
 .. _mail_extra_headers:
 
 Adding extra headers

--- a/docs/summarisinglogger.txt
+++ b/docs/summarisinglogger.txt
@@ -535,6 +535,38 @@ An Error
   For performance reasons, it's recommended that you don't use SMTP
   authentication unless you absolutely need to.
 
+
+If the smtp server you wish to use requires TLS (Transport Level Security),
+pass the required username and password and the secure parameter to the
+:class:`SummarisingLogger` constructor. ``secure`` must be an empty tuple or
+contain one or two members. See the `smtplib`__ documentation for details:
+
+__ https://docs.python.org/3/library/smtplib.html
+
+.. invisible-code-block: python
+
+  logging.getLogger('').removeHandler(handler)
+
+>>> handler = SummarisingLogger('from@example.com',('to@example.com',),
+...                         username='auser',password='theirpassword',
+...                         secure=())
+>>> logger.addHandler(handler)
+>>> logging.error('An Error')
+sending to ('to@example.com',) from 'from@example.com' using ('localhost', 25)
+(authenticated using username:'auser' and password:'theirpassword')
+Content-Transfer-Encoding: 7bit
+Content-Type: text/plain; charset="us-ascii"
+Date: ...
+From: from@example.com
+MIME-Version: 1.0
+Message-ID: <...MailingLogger@...>
+Subject: An Error
+To: to@example.com
+X-Log-Level: ERROR
+X-Mailer: MailingLogger...
+<BLANKLINE>
+An Error
+
 .. _sum_extra_headers:
 
 Adding extra headers

--- a/mailinglogger/mailinglogger.py
+++ b/mailinglogger/mailinglogger.py
@@ -36,7 +36,8 @@ class MailingLogger(SMTPHandler):
                  headers=None,
                  template=None,
                  charset='utf-8',
-                 content_type='text/plain'):
+                 content_type='text/plain',
+                 secure = None):
         SMTPHandler.__init__(self, mailhost, fromaddr, toaddrs, subject)
         self.subject_formatter = SubjectFormatter(subject)
         self.send_empty_entries = send_empty_entries
@@ -49,6 +50,7 @@ class MailingLogger(SMTPHandler):
         self.template = template
         self.charset = charset
         self.content_type = content_type
+        self.secure = secure
         if not self.mailport:
             self.mailport = smtplib.SMTP_PORT
 
@@ -109,6 +111,9 @@ class MailingLogger(SMTPHandler):
             email['Message-ID'] = make_msgid('MailingLogger')
             smtp = smtplib.SMTP(self.mailhost, self.mailport)
             if self.username and self.password:
+                if self.secure is not None:
+                    smtp.starttls(*self.secure)
+                    smtp.ehlo()
                 smtp.login(self.username, self.password)
             smtp.sendmail(self.fromaddr, self.toaddrs, email.as_string())
             smtp.quit()

--- a/mailinglogger/summarisinglogger.py
+++ b/mailinglogger/summarisinglogger.py
@@ -30,6 +30,7 @@ class SummarisingLogger(FileHandler):
                  template=None,
                  charset='utf-8',
                  content_type='text/plain',
+                 secure=None,  # if tuple with 0, 1, or 2 arguments: use TLS. See smtplib.SMTP.starttls
                  flood_level=100,
                  ):
         # create the "real" mailinglogger
@@ -43,7 +44,8 @@ class SummarisingLogger(FileHandler):
                                     headers=headers,
                                     template=template,
                                     charset=charset,
-                                    content_type=content_type)
+                                    content_type=content_type,
+                                    secure=secure)
         # set the mailing logger's log format
         self.mailer.setFormatter(Formatter('%(message)s'))
         self.send_level = send_level


### PR DESCRIPTION
This PR extends the `MailingLogger` and `SummarisingLogger` constructors to take an additional `secure` parameter. If set to an empty tuple or one containing information required by the `SMTP.starttls()` function, and username/password are provided, TLS will be used to connect to the mail server.