### PR TITLE
Fix tests on Windows

### DIFF
--- a/mailinglogger/tests/shared.py
+++ b/mailinglogger/tests/shared.py
@@ -1,9 +1,13 @@
 from __future__ import print_function
 
+
 import logging
 import smtplib
 from collections import namedtuple
-from time import tzset
+from sys import platform
+
+if platform != "win32":
+    from time import tzset
 
 from testfixtures import Replacer, test_datetime, test_time
 
@@ -113,7 +117,8 @@ def _setUp(d, stdout=True):
     r.replace('mailinglogger.common.gethostname', Dummy('host.example.com'))
     r.replace('time.time', time)
     r.replace('os.environ.TZ', 'GMT', strict=False)
-    tzset()
+    if platform != "win32":
+        tzset()
 
     d['atexit_handlers'] = atexit_handlers
     d['r'] = r
@@ -126,6 +131,7 @@ def _setUp(d, stdout=True):
 def _tearDown(d):
     # restore stuff we've mocked out
     d['r'].restore()
-    tzset()
+    if platform != "win32":
+        tzset()
     # make sure we have no dummy smtp
     DummySMTP.remove()


### PR DESCRIPTION
The test framework fails on Windows due to the use of `tzset` which is only available on Unix. This PR uses `tzset` only on supported platforms.